### PR TITLE
Supporting Multiple Deployments in a single build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/environmentdashboard/DeploymentView.java
+++ b/src/main/java/org/jenkinsci/plugins/environmentdashboard/DeploymentView.java
@@ -48,7 +48,8 @@ public class DeploymentView extends ListView {
 
         return runs
                 .stream()
-                .map(run -> run.getAction(DeploymentAction.class))
+                .map(run -> run.getActions(DeploymentAction.class))
+                .flatMap(List::stream)
                 .filter(Objects::nonNull)
                 .collect(Collectors.groupingBy(DeploymentAction::getEnv))
                 .entrySet()


### PR DESCRIPTION
Consider` a job that deploys to multiple environments. The View only shows the details of the first environment. The change enables all the environment deployments for a single build.

Sample Jenkins pipeline that deploys to multiple environments:
```
pipeline` {
    agent any
    stages {
        stage('Deploy to DEV') {
            steps {
                input message: 'Deploy to DEV'
            addDeployToDashboard(env: 'DEV', buildNumber: "$BUILD_NUMBER")
            }
            
        }
        
        stage('Deploy to QA') {
            steps {
                input message: 'Deploy to QA'
            addDeployToDashboard(env: 'QA', buildNumber: "$BUILD_NUMBER")
            }
            
        }
        
        stage('Deploy to PROD') {
            steps {
                input message: 'Deploy to PROD'
            addDeployToDashboard(env: 'PROD', buildNumber: "$BUILD_NUMBER")
            }
            
        }
    }
}
```