### PR TITLE
Deploy permissions

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/environmentdashboard/DeploymentView.java
+++ b/src/main/java/org/jenkinsci/plugins/environmentdashboard/DeploymentView.java
@@ -48,8 +48,7 @@ public class DeploymentView extends ListView {
 
         return runs
                 .stream()
-                .map(run -> run.getActions(DeploymentAction.class))
-                .flatMap(List::stream)
+                .map(run -> run.getAction(DeploymentAction.class))
                 .filter(Objects::nonNull)
                 .collect(Collectors.groupingBy(DeploymentAction::getEnv))
                 .entrySet()

--- a/src/main/java/org/jenkinsci/plugins/environmentdashboard/DeploymentView.java
+++ b/src/main/java/org/jenkinsci/plugins/environmentdashboard/DeploymentView.java
@@ -48,7 +48,8 @@ public class DeploymentView extends ListView {
 
         return runs
                 .stream()
-                .map(run -> run.getAction(DeploymentAction.class))
+                .map(run -> run.getActions(DeploymentAction.class))
+                .flatMap(List::stream)
                 .filter(Objects::nonNull)
                 .collect(Collectors.groupingBy(DeploymentAction::getEnv))
                 .entrySet()


### PR DESCRIPTION
Requirement: Show / Hide Deployment links based on User/Group roles. 
Solution: Added two new parameters users and groups that take in a comma separated list of users and groups respectively who have access to deploy.
Example:
No permission check:
```
buildAddUrl(title: 'Deploy to DEV', url: "/link/to/deployment")
```
Check user list:
```
buildAddUrl(title: 'Deploy to QA', url: "/link/to/deployment", users: "user1,user2,user3")
```
Check group list:
```
buildAddUrl(title: 'Deploy to QA', url: "/link/to/deployment", groups: "group1,group2")
```
Check both:
```
buildAddUrl(title: 'Deploy to QA', url: "/link/to/deployment", users: "user1", groups: "group1,group2")
```